### PR TITLE
The modes returned were off by one, fixed

### DIFF
--- a/girder/molecules/server/calculation.py
+++ b/girder/molecules/server/calculation.py
@@ -79,7 +79,13 @@ class Calculation(Resource):
 
         projection = {
             'vibrationalModes.modeFrames': {
-                '$slice': [index-1, 1]
+                '$slice': [index, 1]
+            },
+            'vibrationalModes.frequencies': {
+                '$slice': [index, 1]
+            },
+            'vibrationalModes.intensities': {
+                '$slice': [index, 1]
             }
         }
 


### PR DESCRIPTION
The index is already a zero-based index, no need to decrement again.
Apply the slice to other parameters too in order to only return data
for the selected mode.