### PR TITLE
Make queries case insensitive

### DIFF
--- a/girder/molecules/server/query.py
+++ b/girder/molecules/server/query.py
@@ -97,12 +97,15 @@ class StringEquals(Comparison):
         #    value = value.replace('InChI=', '')
 
         value = value.strip()
-        if '*' in value:
-            value = value.replace('*', '.*')
-            value = value.replace('(', '\(')
-            value = value.replace('[', '\[')
-            value = value.replace('+', '\+')
-            value = re.compile('^%s$' % value)
+
+        # For now treat everything as a regex so we can support case insensitive
+        # matching. We should really store everything in lowercase so that we
+        # can do direct match with out regex as this is more efficient.
+        value = value.replace('*', '.*')
+        value = value.replace('(', '\(')
+        value = value.replace('[', '\[')
+        value = value.replace('+', '\+')
+        value = re.compile('^%s$' % value, flags=re.IGNORECASE)
 
         return {self.args[0]: value}
 


### PR DESCRIPTION
In the future we should store a lowercase version of these fields
so we can do direct matches ( using the index ... )