### PR TITLE
Don't need current user for cache, public API

### DIFF
--- a/girder/molecules/server/calculation.py
+++ b/girder/molecules/server/calculation.py
@@ -177,7 +177,7 @@ class Calculation(Resource):
             del cjson['vibrations']
 
         # Cache this cube for the next time, they can take a while to generate.
-        self._cube_model.create(getCurrentUser(), id, mo, cjson)
+        self._cube_model.create(id, mo, cjson)
 
         return cjson
 

--- a/girder/molecules/server/models/cubecache.py
+++ b/girder/molecules/server/models/cubecache.py
@@ -33,14 +33,13 @@ class Cubecache(AccessControlledModel):
 
         return doc
 
-    def create(self, user, calcId, mo, cjson):
+    def create(self, calcId, mo, cjson):
         cache = {
             'calculationId': calcId,
             'mo': mo,
             'cjson': cjson
         }
 
-        self.setUserAccess(cache, user=user, level=AccessType.ADMIN)
         # For now set as public
         self.setPublic(cache, True)
 


### PR DESCRIPTION
The cube cache is public API, and shouldn't need/require a user.