### PR TITLE
Fix molecule server error if attributes missing

### DIFF
--- a/girder/molecules/server/models/molecule.py
+++ b/girder/molecules/server/models/molecule.py
@@ -29,8 +29,8 @@ class Molecule(AccessControlledModel):
         cursor = self.find(query)
         mols = list()
         for mol in cursor:
-            molecule = { 'id': mol['_id'], 'inchikey': mol['inchikey'],
-                         'name': mol['name']}
+            molecule = { 'id': mol['_id'], 'inchikey': mol.get('inchikey'),
+                         'name': mol.get('name')}
             mols.append(molecule)
         return mols
 


### PR DESCRIPTION
Some of these attributes are not required for molecules. For instance,
if a molecule is created via xyz, a name will not necessarily be
given to it.

If there are any molecules in the database without a name, GET
'/molecules' would cause a server error.

This fixes the server error.