### PR TITLE
Fix web api param from "inchi" to "inchikey"

### DIFF
--- a/girder/molecules/server/molecule.py
+++ b/girder/molecules/server/molecule.py
@@ -81,7 +81,7 @@ class Molecule(Resource):
         return self._clean(mol)
     find_inchikey.description = (
             Description('Find a molecule by InChI key.')
-            .param('inchi', 'The InChI key of the molecule', paramType='path')
+            .param('inchikey', 'The InChI key of the molecule', paramType='path')
             .errorResponse()
            .errorResponse('Molecule not found.', 404))
 


### PR DESCRIPTION
For GET /molecules/inchikey/{inchikey}, the web api should have
an "inchikey" param, not "inchi".

This fixes it and makes it work properly.