### PR TITLE
Create Molecule: use openbabel to get the formula

### DIFF
--- a/girder/molecules/plugin_tests/__init__.py
+++ b/girder/molecules/plugin_tests/__init__.py
@@ -20,9 +20,9 @@
 import pytest
 import os
 
-# Our method for creating a molecule
 @pytest.fixture
 def molecule(user):
+    """Our method for creating a molecule within girder."""
     from girder.plugins.molecules.models.molecule import Molecule
     from girder.plugins.molecules import openbabel
 
@@ -36,11 +36,15 @@ def molecule(user):
     name = 'ethane'
 
     (inchi, inchikey) = openbabel.to_inchi(data, input_format)
+    formula = openbabel.get_formula(data, input_format)
+
+    properties = {'formula': formula}
 
     mol = {
         'inchi': inchi,
         'inchikey': inchikey,
-        'name': name
+        'name': name,
+        'properties': properties
     }
 
     mol = Molecule().create_xyz(user, mol, public=False)
@@ -54,9 +58,9 @@ def molecule(user):
     # Delete mol
     Molecule().remove(mol)
 
-# Our method for creating a calculation
 @pytest.fixture
 def calculation(user, molecule):
+    """Our method for creating a calculation within girder."""
     from girder.plugins.molecules.models.calculation import Calculation
 
     assert '_id' in molecule

--- a/girder/molecules/plugin_tests/molecules_test.py
+++ b/girder/molecules/plugin_tests/molecules_test.py
@@ -25,6 +25,7 @@ from pytest_girder.assertions import assertStatusOk
 
 from . import molecule
 
+
 @pytest.mark.plugin('molecules')
 def test_create_molecule(server, user):
     from girder.plugins.molecules.models.molecule import Molecule
@@ -36,8 +37,8 @@ def test_create_molecule(server, user):
         xyz_data = rf.read()
 
     body = {
-      'name': 'ethane',
-      'xyz': xyz_data
+        'name': 'ethane',
+        'xyz': xyz_data
     }
 
     r = server.request('/molecules', method='POST', type='application/json',
@@ -66,6 +67,7 @@ def test_create_molecule(server, user):
     r = server.request('/molecules/%s' % id, method='DELETE', user=user)
     assertStatusOk(r)
 
+
 @pytest.mark.plugin('molecules')
 def test_get_molecule(server, molecule, user):
 
@@ -83,7 +85,7 @@ def test_get_molecule(server, molecule, user):
     name = molecule['name']
 
     # Find the molecule by name
-    params = { 'name': name }
+    params = {'name': name}
     r = server.request('/molecules', method='GET', params=params, user=user)
     assertStatusOk(r)
 
@@ -96,7 +98,7 @@ def test_get_molecule(server, molecule, user):
     assert mol.get('name') == name
 
     # Find the molecule by inchi
-    params = { 'inchi': inchi }
+    params = {'inchi': inchi}
     r = server.request('/molecules', method='GET', params=params, user=user)
     assertStatusOk(r)
 
@@ -109,7 +111,7 @@ def test_get_molecule(server, molecule, user):
     assert mol.get('name') == name
 
     # Find the molecule by inchikey
-    params = { 'inchikey': inchikey }
+    params = {'inchikey': inchikey}
     r = server.request('/molecules', method='GET', params=params, user=user)
     assertStatusOk(r)
 
@@ -120,6 +122,7 @@ def test_get_molecule(server, molecule, user):
     assert mol.get('id') == _id
     assert mol.get('inchikey') == inchikey
     assert mol.get('name') == name
+
 
 @pytest.mark.plugin('molecules')
 def test_get_molecule_inchikey(server, molecule, user):
@@ -148,3 +151,43 @@ def test_get_molecule_inchikey(server, molecule, user):
     assert mol.get('inchi') == inchi
     assert mol.get('inchikey') == inchikey
     assert mol.get('name') == name
+
+
+@pytest.mark.plugin('molecules')
+def test_search_molecule_formula(server, molecule, user):
+
+    # The molecule will have been created by the fixture
+    assert '_id' in molecule
+    assert 'inchi' in molecule
+    assert 'inchikey' in molecule
+    assert 'properties' in molecule
+    assert 'formula' in molecule['properties']
+
+    # This one is not essential, but we set it ourselves
+    assert 'name' in molecule
+
+    _id = molecule['_id']
+    inchi = molecule['inchi']
+    inchikey = molecule['inchikey']
+    name = molecule['name']
+    formula = molecule['properties']['formula']
+
+    ethane_formula = 'C2H6'
+    assert formula == ethane_formula
+
+    # Find the molecule by its formula. Formula here is C2H6.
+    params = {'formula': ethane_formula}
+    r = server.request('/molecules/search', method='GET', user=user,
+                       params=params)
+    assertStatusOk(r)
+
+    # Should just be one
+    assert len(r.json) == 1
+    mol = r.json[0]
+
+    # Everything should match
+    assert mol.get('_id') == _id
+    assert mol.get('inchi') == inchi
+    assert mol.get('inchikey') == inchikey
+    assert mol.get('name') == name
+    assert mol.get('properties').get('formula') == ethane_formula

--- a/girder/molecules/server/molecule.py
+++ b/girder/molecules/server/molecule.py
@@ -269,11 +269,17 @@ class Molecule(Resource):
                 data = body['sdf']
 
             (inchi, inchikey) = openbabel.to_inchi(data, input_format)
+            formula = openbabel.get_formula(data, input_format)
+
+            properties = {
+              'formula': formula
+            }
 
             mol = {
                 'inchi': inchi,
                 'inchikey': inchikey,
-                input_format: data
+                input_format: data,
+                'properties': properties
             }
 
             if 'name' in body:
@@ -536,5 +542,5 @@ class Molecule(Resource):
     search.description = (
             Description('Search for molecules using a query string or formula')
             .param('q', 'The query string to use for this search', paramType='query', required=False)
-            .param('formula', 'The formula to search for', paramType='query', required=False)
+            .param('formula', 'The formula (using the "Hill Order") to search for', paramType='query', required=False)
             .param('cactus', 'The identifier to pass to cactus', paramType='query', required=False))

--- a/girder/molecules/server/openbabel.py
+++ b/girder/molecules/server/openbabel.py
@@ -37,3 +37,13 @@ def atom_count(str_data, in_format):
     conv.ReadString(mol, str_data)
 
     return mol.NumAtoms()
+
+def get_formula(str_data, in_format):
+    # Get the molecule using the "Hill Order" - i. e., C first, then H,
+    # and then alphabetical.
+    mol = OBMol()
+    conv = OBConversion()
+    conv.SetInFormat(in_format)
+    conv.ReadString(mol, str_data)
+
+    return mol.GetFormula()


### PR DESCRIPTION
When creating a molecule via "xyz" or "sdf", get the formula
in the "Hill Ordering" - that is, C first, then H, then the rest
of the elements in alphabetical order.

I also added a test for this as well.