### PR TITLE
Molecule create: only check experiment for nwchem

### DIFF
--- a/girder/molecules/server/molecule.py
+++ b/girder/molecules/server/molecule.py
@@ -146,11 +146,13 @@ class Molecule(Resource):
             contents = functools.reduce(lambda x, y: x + y, self.model('file').download(file, headers=False)())
             data_str = contents.decode()
 
-            # For now piggy backing experimental results upload here!
-            # This should be refactored ...
-            json_data = json.loads(data_str)
-            if 'experiment' in json_data:
-                return self._process_experimental(json_data)
+            # Only perform the following check if we are using nwchem format
+            if input_format == 'nwchem':
+                # For now piggy backing experimental results upload here!
+                # This should be refactored ...
+                json_data = json.loads(data_str)
+                if 'experiment' in json_data:
+                    return self._process_experimental(json_data)
 
             # Use the SDF format as it is the one with bonding that 3Dmol uses.
             output_format = 'sdf'


### PR DESCRIPTION
This prevents a server error when it tries to load the input data
as a json string but the input data may not be a json string.