### PR TITLE
Remove --process-dependency-links

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,7 +28,7 @@ COPY docker/girder.local.conf /girder/girder/conf/girder.local.cfg
 COPY . /mongochemserver
 
 # Install mongochemserver
-RUN pip install --no-cache-dir --process-dependency-links -r /mongochemserver/requirements.txt && \
+RUN pip  install --no-cache-dir -r /mongochemserver/requirements.txt && \
   girder-install plugin /mongochemserver/girder/molecules && \
   girder-install plugin /mongochemserver/girder/notebooks && \
   girder-install plugin /mongochemserver/girder/queues


### PR DESCRIPTION
This option has been removed in pip 19.0. Its not clear why we were using it.