### PR TITLE
MongoChemServer changes to query spectra 

### DIFF
--- a/girder/molecules/server/experiment.py
+++ b/girder/molecules/server/experiment.py
@@ -85,7 +85,7 @@ class Experiment(Resource):
             from .nist import search_nist_inchi, get_jdx
             from jcamp import jcamp_read
 
-            inchi = params['molecularFormula']      # TODO change API to accept
+            inchi = params['inchi']      # TODO change API to accept
                                                     # a different key. From
                                                     # molecularFormula to inchi?
             stype = params['spectrum_type']

--- a/girder/molecules/server/experiment.py
+++ b/girder/molecules/server/experiment.py
@@ -85,9 +85,7 @@ class Experiment(Resource):
             from .nist import search_nist_inchi, get_jdx
             from jcamp import jcamp_read
 
-            inchi = params['inchi']      # TODO change API to accept
-                                                    # a different key. From
-                                                    # molecularFormula to inchi?
+            inchi = params['inchi']
             stype = params['spectrum_type']
             nist_identifier =  search_nist_inchi(inchi)
             jdx = get_jdx(nist_identifier, stype=stype)

--- a/girder/molecules/server/experiment.py
+++ b/girder/molecules/server/experiment.py
@@ -14,6 +14,7 @@ from girder.constants import AccessType, TokenScope
 
 from girder.plugins.molecules.models.experimental import Experimental
 
+
 class Experiment(Resource):
 
     def __init__(self):
@@ -80,15 +81,29 @@ class Experiment(Resource):
     def find_experiment(self, params):
         user = getCurrentUser()
 
-        query = { }
-        if 'molecularFormula' in params:
-            query['molecularFormula'] = params['molecularFormula']
+        if 'source' in params.keys():
+            from .nist import search_nist_inchi, get_jdx
+            from jcamp import jcamp_read
 
-        limit = int(params.get('limit', 50))
-        experiments = self._model.find(query, limit=limit)
+            inchi = params['molecularFormula']      # TODO change API to accept
+                                                    # a different key. From
+                                                    # molecularFormula to inchi?
+            stype = params['spectrum_type']
+            nist_identifier =  search_nist_inchi(inchi)
+            jdx = get_jdx(nist_identifier, stype=stype)
 
-        return  [self._model.filter(x, user) for x in experiments]
+            ir = jcamp_read(jdx)
+            return ir
 
+        else:
+            query = { }
+            if 'molecularFormula' in params:
+                query['molecularFormula'] = params['molecularFormula']
+
+            limit = int(params.get('limit', 50))
+            experiments = self._model.find(query, limit=limit)
+
+            return  [self._model.filter(x, user) for x in experiments]
 
     find_experiment.description = (
         Description('Get the calculation types available for the molecule')

--- a/girder/molecules/server/experiment.py
+++ b/girder/molecules/server/experiment.py
@@ -81,7 +81,7 @@ class Experiment(Resource):
     def find_experiment(self, params):
         user = getCurrentUser()
 
-        if 'source' in params.keys():
+        if 'source' in params:
             from .nist import search_nist_inchi, get_jdx
             from jcamp import jcamp_read
 

--- a/girder/molecules/server/nist.py
+++ b/girder/molecules/server/nist.py
@@ -1,6 +1,5 @@
 import re
 import requests
-import os
 from bs4 import BeautifulSoup
 
 
@@ -23,28 +22,21 @@ def search_nist_inchi(inchi, stype='IR'):
     """
     EXACT_RE = re.compile('/cgi/cbook.cgi\?GetInChI=(.*?)$')
 
-    print('Searching: {}' .format(inchi))
     response = requests.get(NIST_URL, params={'InChI': inchi, 'Units': 'SI'})
     soup = BeautifulSoup(response.text)
     idlink = soup.find('a', href=EXACT_RE)
     if idlink:
         nistid = re.match(EXACT_RE, idlink['href']).group(1)
-        print('Result: {}' .format(nistid))
         return nistid
 
 
 def get_jdx(nistid, stype='IR'):
-    """Download jdx file for the specified NIST ID."""
-    filepath = os.path.join(JDX_PATH, '{}-{}.jdx' .format(nistid, stype))
-    if os.path.isfile(filepath):
-        print('{} {}: Already exists at {}' .format(nistid, stype, filepath))
-        return
-    print('{} {}: Downloading' .format(nistid, stype))
+    """Get jdx file content for the specified NIST ID."""
     response = requests.get(NIST_URL, params={'JCAMP': nistid, 'Type': stype,
                                               'Index': 0})
     if response.text == '##TITLE=Spectrum not found.\n##END=\n':
-        print('{} {}: Spectrum not found' .format(nistid, stype))
         return
-    print('Saving {}' .format(filepath))
-    with open(filepath, 'wb') as file:
-        file.write(response.content)
+    else:
+        content = response.content.splitlines()
+        content = [line.decode("utf-8") for line in content]
+        return content

--- a/girder/molecules/server/nist.py
+++ b/girder/molecules/server/nist.py
@@ -1,0 +1,50 @@
+import re
+import requests
+import os
+from bs4 import BeautifulSoup
+
+
+# Variables controlled by admins
+JDX_PATH = 'nist/jdx/'
+NIST_URL = 'http://webbook.nist.gov/cgi/cbook.cgi'
+
+
+def search_nist_inchi(inchi, stype='IR'):
+    """Search NIST using the specified InChI or InChIKey
+
+    This function queries and returns the matching NIST ID.
+
+    Parameters
+    ----------
+    inchi : str
+        An Inchi string.
+    stype : str
+        Type of spectrum to be downloaded.
+    """
+    EXACT_RE = re.compile('/cgi/cbook.cgi\?GetInChI=(.*?)$')
+
+    print('Searching: {}' .format(inchi))
+    response = requests.get(NIST_URL, params={'InChI': inchi, 'Units': 'SI'})
+    soup = BeautifulSoup(response.text)
+    idlink = soup.find('a', href=EXACT_RE)
+    if idlink:
+        nistid = re.match(EXACT_RE, idlink['href']).group(1)
+        print('Result: {}' .format(nistid))
+        return nistid
+
+
+def get_jdx(nistid, stype='IR'):
+    """Download jdx file for the specified NIST ID."""
+    filepath = os.path.join(JDX_PATH, '{}-{}.jdx' .format(nistid, stype))
+    if os.path.isfile(filepath):
+        print('{} {}: Already exists at {}' .format(nistid, stype, filepath))
+        return
+    print('{} {}: Downloading' .format(nistid, stype))
+    response = requests.get(NIST_URL, params={'JCAMP': nistid, 'Type': stype,
+                                              'Index': 0})
+    if response.text == '##TITLE=Spectrum not found.\n##END=\n':
+        print('{} {}: Spectrum not found' .format(nistid, stype))
+        return
+    print('Saving {}' .format(filepath))
+    with open(filepath, 'wb') as file:
+        file.write(response.content)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,7 @@ rdflib==4.2.1
 avogadro==1.92.1
 openchemistry
 numpy
+beautifulsoup4
+jcamp
+requests
 -e git+git://github.com/cclib/cclib.git#egg=cclib


### PR DESCRIPTION
This PR intends to close https://github.com/OpenChemistry/42/issues/7. It contains the following changes:

1. A new `nist` module was added. It contains functions to download `jdx` files from NIST. It adds two dependecies: `bs4`, and `jcamp`.
1.  A `find_experiment()` function was modified to operate with the new added `nist` module. It returns a dictionary with spectrum's data. 

TODO:

- [x]  Make the API accept `params['inchi']` for inchi strings instead of using `params['molecularFormula']`.  to pass the inchi string. Bad hack but worked for proof of concept. 