### PR TITLE
Allow 'chemical json' for cjson version key

### DIFF
--- a/girder/molecules/server/utilities/molecules.py
+++ b/girder/molecules/server/utilities/molecules.py
@@ -59,11 +59,19 @@ def create_molecule(data_str, input_format, user, public):
 
         smiles = openbabel.to_smiles(sdf_data, sdf_format)
 
+        # Find the cjson version key
+        version_key = 'chemicalJson'
+        if version_key not in cjson:
+            if 'chemical json' in cjson:
+                version_key = 'chemical json'
+            else:
+                raise RestException('No "chemicalJson" key found', 400)
+
         # Whitelist parts of the CJSON that we store at the top level.
         cjsonmol = {}
         cjsonmol['atoms'] = cjson['atoms']
         cjsonmol['bonds'] = cjson['bonds']
-        cjsonmol['chemicalJson'] = cjson['chemicalJson']
+        cjsonmol['chemicalJson'] = cjson[version_key]
         mol_dict = {
             'name': chemspider.find_common_name(inchikey, props['formula']),
             'inchi': inchi,


### PR DESCRIPTION
'chemical json' was used for cjson version 0. Allow
this key to be used.

Signed-off-by: Patrick Avery <patrick.avery@kitware.com>