### PR TITLE
Updated to adapt to changed CACTUS API

### DIFF
--- a/girder/molecules/server/molecule.py
+++ b/girder/molecules/server/molecule.py
@@ -359,7 +359,7 @@ class Molecule(Resource):
         elif cactus:
             # Disable cert verification for now
             # TODO Ensure we have the right root certs so this just works.
-            r = requests.get('https://cactus.nci.nih.gov/chemical/structure/%s/sdf' % cactus, verify=False)
+            r = requests.get('https://cactus.nci.nih.gov/chemical/structure/%s/file?format=sdf' % cactus, verify=False)
 
             if r.status_code == 404:
                 return []


### PR DESCRIPTION
They appear to have changed their API, not sure what the return is from
/sdf now, but file?format=sdf returns the SDF format we want.