### PR TITLE
Do not add default names for molecules

### DIFF
--- a/girder/molecules/server/chemspider.py
+++ b/girder/molecules/server/chemspider.py
@@ -9,10 +9,10 @@ except KeyError:
     print(TerminalColor.warning('WARNING: chemspikey not set, common names will not be resolved.'))
 
 
-def find_common_name(inchikey, formula):
-    # Try to find the common name for the compound, if not use the formula.
+def find_common_name(inchikey):
+    # Try to find the common name for the compound, if not use an empty string.
 
-    name = formula
+    name = ''
 
     if chemspikey:
         cs = ChemSpider(chemspikey)

--- a/girder/molecules/server/chemspider.py
+++ b/girder/molecules/server/chemspider.py
@@ -10,9 +10,9 @@ except KeyError:
 
 
 def find_common_name(inchikey):
-    # Try to find the common name for the compound, if not use an empty string.
+    # Try to find the common name for the compound, if not, return None.
 
-    name = ''
+    name = None
 
     if chemspikey:
         cs = ChemSpider(chemspikey)

--- a/girder/molecules/server/models/molecule.py
+++ b/girder/molecules/server/models/molecule.py
@@ -36,8 +36,10 @@ class Molecule(AccessControlledModel):
         mols = list()
         for mol in cursor:
             molecule = { '_id': mol['_id'], 'inchikey': mol.get('inchikey'),
-                         'smiles': mol.get('smiles'), 'name': mol.get('name'),
+                         'smiles': mol.get('smiles'),
                          'properties': mol.get('properties') }
+            if 'name' in mol:
+                molecule['name'] = mol['name']
             mols.append(molecule)
         return mols
 

--- a/girder/molecules/server/semantic/cheminf.py
+++ b/girder/molecules/server/semantic/cheminf.py
@@ -10,7 +10,7 @@ def create_molecule_graph(uri_base, mol):
     mongochem = Namespace('%s/api/v1/molecules/' % uri_base)
     g = Graph()
     inchi = mol['inchi']
-    name = mol['name']
+    name = mol.get('name')
     inchi_node = BNode()
 
     molecule = URIRef(mongochem[mol['_id']])
@@ -21,7 +21,10 @@ def create_molecule_graph(uri_base, mol):
     namespace_manager.bind('owl', OWL, override=False)
 
     g.add((molecule, OWL.subClassOf, cheminf.CHEMINF_000000))
-    g.add((molecule, OWL.label, Literal(name.lower())))
+
+    if name is not None:
+        g.add((molecule, OWL.label, Literal(name.lower())))
+
     g.add((inchi_node, RDF.type, cheminf.CHEMINF_000113))
     g.add((inchi_node, cheminf.SIO_000300, Literal(inchi)))
     g.add((molecule, cheminf.CHEMINF_000200, inchi_node))

--- a/girder/molecules/server/utilities/molecules.py
+++ b/girder/molecules/server/utilities/molecules.py
@@ -76,7 +76,7 @@ def create_molecule(data_str, input_format, user, public):
         cjsonmol['bonds'] = cjson['bonds']
         cjsonmol['chemicalJson'] = cjson[version_key]
         mol_dict = {
-            'name': chemspider.find_common_name(inchikey, props['formula']),
+            'name': chemspider.find_common_name(inchikey),
             'inchi': inchi,
             'inchikey': inchikey,
             'smiles': smiles,

--- a/girder/molecules/server/utilities/molecules.py
+++ b/girder/molecules/server/utilities/molecules.py
@@ -76,7 +76,6 @@ def create_molecule(data_str, input_format, user, public):
         cjsonmol['bonds'] = cjson['bonds']
         cjsonmol['chemicalJson'] = cjson[version_key]
         mol_dict = {
-            'name': chemspider.find_common_name(inchikey),
             'inchi': inchi,
             'inchikey': inchikey,
             'smiles': smiles,
@@ -86,6 +85,12 @@ def create_molecule(data_str, input_format, user, public):
             'atomCounts': atomCounts,
             'svg': svg_data
         }
+
+        # Set a name if we find one
+        name = chemspider.find_common_name(inchikey)
+        if name is not None:
+            mol_dict['name'] = name
+
         mol = MoleculeModel().create(user, mol_dict, public)
 
         # Upload the molecule to virtuoso


### PR DESCRIPTION
This is done so that it is more easily detectable whether
a name has been set or not.

This is done as per the discussion [here](https://github.com/OpenChemistry/mongochemclient/pull/111).

Signed-off-by: Patrick Avery <patrick.avery@kitware.com>