### PR TITLE
Updates for the girder 3 changes in past month

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update && apt-get -y install \
   libopenbabel-dev
 
 # Enable proxy support
-COPY docker/girder.local.conf /girder/girder/conf/girder.local.cfg
+COPY docker/girder.local.conf /etc/girder.cfg
 
 # Copy over mongochemserver
 COPY . /mongochemserver

--- a/girder/notebooks/notebooks/__init__.py
+++ b/girder/notebooks/notebooks/__init__.py
@@ -18,6 +18,7 @@ def createNotebooks(event):
     try:
         Assetstore().getCurrent()
     except GirderException:
+        print('Warning: no current asset store. Notebook will not be created.')
         return
 
     user = event.info

--- a/girder/notebooks/notebooks/__init__.py
+++ b/girder/notebooks/notebooks/__init__.py
@@ -3,6 +3,8 @@ import glob
 from bson.objectid import ObjectId
 
 from girder import events
+from girder.exceptions import GirderException
+from girder.models.assetstore import Assetstore
 from girder.models.folder import Folder
 from girder.models.upload import Upload
 from girder.plugin import GirderPlugin
@@ -11,6 +13,13 @@ from girder.utility.path import lookUpPath
 from .rest import Notebook
 
 def createNotebooks(event):
+
+    # If there is no current asset store, just return
+    try:
+        Assetstore().getCurrent()
+    except GirderException:
+        return
+
     user = event.info
     folder_model = Folder()
 

--- a/girder/notebooks/notebooks/__init__.py
+++ b/girder/notebooks/notebooks/__init__.py
@@ -3,6 +3,7 @@ import glob
 from bson.objectid import ObjectId
 
 from girder import events
+from girder.constants import TerminalColor
 from girder.exceptions import GirderException
 from girder.models.assetstore import Assetstore
 from girder.models.folder import Folder
@@ -18,7 +19,8 @@ def createNotebooks(event):
     try:
         Assetstore().getCurrent()
     except GirderException:
-        print('Warning: no current asset store. Notebook will not be created.')
+        print(TerminalColor.warning('WARNING: no current asset store. '
+                                    'Notebook will not be created.'))
         return
 
     user = event.info


### PR DESCRIPTION
Here are the summaries of the commits:

Put girder config file in /etc/girder.cfg
============================

The previous location of the girder config file is no longer
supported as of [this commit](https://github.com/girder/girder/commit/fbe7a05895d99fe2de297a84a1e9341da1e48ccd).

Move the config file in /etc/girder.cfg instead.

Do not create a notebook if there is no assetstore
=====================================

As of girder 3, in mongochemdeploy, when ansible creates the first user
`mongochemdev`, it also tries to create a notebook due to the notebook
plugin, and an exception gets raised because there is no assestore yet.

Before girder 3, this wouldn't happen because the notebook plugin would
be explicitly enabled after the `mongochemdev` user was created. But in
girder 3, the plugin is enabled automatically at the start if the
plugin was pip installed.

This commit prevents the exception from occurring in ansible.