### PR TITLE
Move formula search to `GET /molecules`

### DIFF
--- a/girder/molecules/molecules/models/molecule.py
+++ b/girder/molecules/molecules/models/molecule.py
@@ -39,6 +39,10 @@ class Molecule(AccessControlledModel):
             if 'smiles' in search:
                 # Make sure it is canonical before searching
                 query['smiles'] = openbabel.to_smiles(search['smiles'], 'smi')
+            if 'formula' in search:
+                formula_regx = re.compile('^%s$' % search['formula'],
+                                          re.IGNORECASE)
+                query['properties.formula'] = formula_regx
             if 'creatorId' in search:
                 query['creatorId'] = ObjectId(search['creatorId'])
 
@@ -63,18 +67,6 @@ class Molecule(AccessControlledModel):
         query = { 'inchikey': inchikey }
         mol = self.findOne(query)
         return mol
-
-    def find_formula(self, formula, user, limit, offset, sort):
-        formula_regx = re.compile('^%s$' % formula, re.IGNORECASE)
-        query = {
-            'properties.formula': formula_regx
-        }
-        mols = self.find(query, limit=limit, offset=offset, sort=sort)
-
-        mols = list(self.filterResultsByPermission(mols, user,
-                                                   level=AccessType.READ))
-
-        return search_results_dict(mols, limit, offset, sort)
 
     def create(self, user, mol, public=False):
 

--- a/girder/molecules/molecules/molecule.py
+++ b/girder/molecules/molecules/molecule.py
@@ -90,6 +90,9 @@ class Molecule(Resource):
                    required=False)
             .param('smiles', 'The SMILES of the molecule', paramType='query',
                    required=False)
+            .param('formula',
+                   'The formula (using the "Hill Order") to search for',
+                   paramType='query', required=False)
             .param('creatorId', 'The id of the user that created the molecule',
                    paramType='query', required=False)
             .pagingParams(defaultSort='_id',
@@ -408,10 +411,9 @@ class Molecule(Resource):
         limit, offset, sort = parse_pagination_params(params)
 
         query_string = params.get('q')
-        formula = params.get('formula')
         cactus = params.get('cactus')
-        if query_string is None and formula is None and cactus is None:
-            raise RestException('Either \'q\', \'formula\' or \'cactus\' is required.')
+        if query_string is None and cactus is None:
+            raise RestException('Either \'q\' or \'cactus\' is required.')
 
         if query_string is not None:
             try:
@@ -428,11 +430,6 @@ class Molecule(Resource):
 
             return search_results_dict(mols, limit, offset, sort)
 
-        elif formula:
-            # Search using formula
-            return MoleculeModel().find_formula(formula, getCurrentUser(),
-                                                limit=limit, offset=offset,
-                                                sort=sort)
         elif cactus:
             if getCurrentUser() is None:
                 raise RestException('Must be logged in to search with cactus.')
@@ -453,9 +450,8 @@ class Molecule(Resource):
 
 
     search.description = (
-            Description('Search for molecules using a query string or formula')
+            Description('Search for molecules using a query string or cactus')
             .param('q', 'The query string to use for this search', paramType='query', required=False)
-            .param('formula', 'The formula (using the "Hill Order") to search for', paramType='query', required=False)
             .param('cactus', 'The identifier to pass to cactus', paramType='query', required=False)
             .pagingParams(defaultSort='_id',
                           defaultSortDir=SortDir.DESCENDING,

--- a/girder/molecules/molecules/molecule.py
+++ b/girder/molecules/molecules/molecule.py
@@ -411,9 +411,10 @@ class Molecule(Resource):
         limit, offset, sort = parse_pagination_params(params)
 
         query_string = params.get('q')
+        formula = params.get('formula')
         cactus = params.get('cactus')
-        if query_string is None and cactus is None:
-            raise RestException('Either \'q\' or \'cactus\' is required.')
+        if query_string is None and formula is None and cactus is None:
+            raise RestException('Either \'q\', \'formula\' or \'cactus\' is required.')
 
         if query_string is not None:
             try:
@@ -429,6 +430,10 @@ class Molecule(Resource):
                 mols.append(mol)
 
             return search_results_dict(mols, limit, offset, sort)
+
+        elif formula:
+            # Search using formula
+            return MoleculeModel().findmol(params)
 
         elif cactus:
             if getCurrentUser() is None:
@@ -450,8 +455,9 @@ class Molecule(Resource):
 
 
     search.description = (
-            Description('Search for molecules using a query string or cactus')
+            Description('Search for molecules using a query string, formula, or cactus')
             .param('q', 'The query string to use for this search', paramType='query', required=False)
+            .param('formula', 'The formula (using the "Hill Order") to search for', paramType='query', required=False)
             .param('cactus', 'The identifier to pass to cactus', paramType='query', required=False)
             .pagingParams(defaultSort='_id',
                           defaultSortDir=SortDir.DESCENDING,

--- a/girder/molecules/plugin_tests/molecules_test.py
+++ b/girder/molecules/plugin_tests/molecules_test.py
@@ -393,7 +393,6 @@ def test_search_molecule_formula(server, molecule, user):
 
     # The molecule will have been created by the fixture
     assert '_id' in molecule
-    assert 'inchi' in molecule
     assert 'inchikey' in molecule
     assert 'smiles' in molecule
     assert 'properties' in molecule
@@ -403,7 +402,6 @@ def test_search_molecule_formula(server, molecule, user):
     assert 'name' in molecule
 
     _id = molecule['_id']
-    inchi = molecule['inchi']
     inchikey = molecule['inchikey']
     smiles = molecule['smiles']
     name = molecule['name']
@@ -414,8 +412,7 @@ def test_search_molecule_formula(server, molecule, user):
 
     # Find the molecule by its formula. Formula here is C2H6.
     params = {'formula': ethane_formula}
-    r = server.request('/molecules/search', method='GET', user=user,
-                       params=params)
+    r = server.request('/molecules', method='GET', user=user, params=params)
     assertStatusOk(r)
 
     # Should just be one
@@ -424,7 +421,6 @@ def test_search_molecule_formula(server, molecule, user):
 
     # Everything should match
     assert mol.get('_id') == _id
-    assert mol.get('inchi') == inchi
     assert mol.get('inchikey') == inchikey
     assert mol.get('smiles') == smiles
     assert mol.get('name') == name


### PR DESCRIPTION
Move formula search from `GET /molecules/search` to
`GET /molecules` for consistent searching.

As far as I can tell, `GET /molecules/search` for a formula was not being used anywhere. So this will hopefully not break anything.