### PR TITLE
Count total number of matches (no limit) for GET

### DIFF
--- a/girder/molecules/molecules/calculation.py
+++ b/girder/molecules/molecules/calculation.py
@@ -439,11 +439,13 @@ class Calculation(Resource):
 
         calcs = self._model.find(query, fields=fields, limit=limit,
                                  offset=offset, sort=sort)
+        num_matches = calcs.collection.count_documents(query)
+
         calcs = self._model.filterResultsByPermission(calcs, user,
             AccessType.READ, limit=limit)
         calcs = [self._model.filter(x, user) for x in calcs]
 
-        return search_results_dict(calcs, limit, offset, sort)
+        return search_results_dict(calcs, num_matches, limit, offset, sort)
 
     @access.public
     def find_id(self, id, params):

--- a/girder/molecules/molecules/models/molecule.py
+++ b/girder/molecules/molecules/models/molecule.py
@@ -47,6 +47,8 @@ class Molecule(AccessControlledModel):
                 query['creatorId'] = ObjectId(search['creatorId'])
 
         cursor = self.find(query, limit=limit, offset=offset, sort=sort)
+        num_matches = cursor.collection.count_documents(query)
+
         mols = list()
         for mol in cursor:
             molecule = { '_id': mol['_id'], 'inchikey': mol.get('inchikey'),
@@ -56,7 +58,7 @@ class Molecule(AccessControlledModel):
                 molecule['name'] = mol['name']
             mols.append(molecule)
 
-        return search_results_dict(mols, limit, offset, sort)
+        return search_results_dict(mols, num_matches, limit, offset, sort)
 
     def find_inchi(self, inchi):
         query = { 'inchi': inchi }

--- a/girder/molecules/molecules/molecule.py
+++ b/girder/molecules/molecules/molecule.py
@@ -422,14 +422,14 @@ class Molecule(Resource):
             except query.InvalidQuery:
                 raise RestException('Invalid query', 400)
 
-            mols = []
-            for mol in MoleculeModel().find(query=mongo_query,
-                                            fields=['_id', 'inchikey', 'name'],
-                                            limit=limit, offset=offset,
-                                            sort=sort):
-                mols.append(mol)
+            cursor = MoleculeModel().find(query=mongo_query,
+                                          fields=['_id', 'inchikey', 'name'],
+                                          limit=limit, offset=offset,
+                                          sort=sort)
+            mols = [x for x in cursor]
+            num_matches = cursor.collection.count_documents(mongo_query)
 
-            return search_results_dict(mols, limit, offset, sort)
+            return search_results_dict(mols, num_matches, limit, offset, sort)
 
         elif formula:
             # Search using formula
@@ -451,7 +451,7 @@ class Molecule(Resource):
             sdf_data = r.content.decode('utf8')
             mol = create_molecule(sdf_data, 'sdf', getCurrentUser(), True)
 
-            return search_results_dict([mol], limit, offset, sort)
+            return search_results_dict([mol], 1, limit, offset, sort)
 
 
     search.description = (

--- a/girder/molecules/molecules/utilities/pagination.py
+++ b/girder/molecules/molecules/utilities/pagination.py
@@ -28,10 +28,10 @@ def parse_pagination_params(params):
     return limit, offset, sort
 
 
-def search_results_dict(results, limit, offset, sort):
+def search_results_dict(results, num_matches, limit, offset, sort):
     """This is for consistent search results"""
     ret = {
-        'matches': len(results),
+        'matches': num_matches,
         'limit': limit,
         'offset': offset,
         'results': results


### PR DESCRIPTION
Before, the number of matches was limited by the limit.
Now it is not, which can be helpful for pagination.

The reason Collection.count_documents() was used instead
of Cursor.count() is because Cursor.count() is deprecated
in favor of Collection.count_documents().

Signed-off-by: Patrick Avery <patrick.avery@kitware.com>