### PR TITLE
Use fields to get specific keys from molecules

### DIFF
--- a/girder/molecules/molecules/models/molecule.py
+++ b/girder/molecules/molecules/models/molecule.py
@@ -46,18 +46,18 @@ class Molecule(AccessControlledModel):
             if 'creatorId' in search:
                 query['creatorId'] = ObjectId(search['creatorId'])
 
-        cursor = self.find(query, limit=limit, offset=offset, sort=sort)
+        fields = [
+          'inchikey',
+          'smiles',
+          'properties',
+          'name'
+        ]
+
+        cursor = self.find(query, fields=fields, limit=limit, offset=offset,
+                           sort=sort)
         num_matches = cursor.collection.count_documents(query)
 
-        mols = list()
-        for mol in cursor:
-            molecule = { '_id': mol['_id'], 'inchikey': mol.get('inchikey'),
-                         'smiles': mol.get('smiles'),
-                         'properties': mol.get('properties') }
-            if 'name' in mol:
-                molecule['name'] = mol['name']
-            mols.append(molecule)
-
+        mols = [x for x in cursor]
         return search_results_dict(mols, num_matches, limit, offset, sort)
 
     def find_inchi(self, inchi):


### PR DESCRIPTION
Using fields like this is a simpler and more efficient
way to choose the keys we want to get from molecules.

For fields like `name` where it may or may not be present,
it does not return anything if `name` is not present.