### PR TITLE
Allow molecules to be searched with min/max values

### DIFF
--- a/girder/molecules/molecules/models/molecule.py
+++ b/girder/molecules/molecules/models/molecule.py
@@ -5,8 +5,9 @@ import json
 from jsonpath_rw import parse
 import re
 
-from girder.models.model_base import AccessControlledModel, ValidationException
+from girder.models.model_base import AccessControlledModel
 from girder.constants import AccessType
+from girder.exceptions import RestException, ValidationException
 from molecules import avogadro
 from molecules import openbabel
 
@@ -45,6 +46,26 @@ class Molecule(AccessControlledModel):
                 query['properties.formula'] = formula_regx
             if 'creatorId' in search:
                 query['creatorId'] = ObjectId(search['creatorId'])
+
+            if 'minValues' in search:
+                try:
+                    minValues = json.loads(search['minValues'])
+                    for key in minValues:
+                        if key not in query:
+                            query[key] = {}
+                        query[key]['$gte'] = minValues[key]
+                except:
+                    raise RestException('Failed to parse minValues')
+
+            if 'maxValues' in search:
+                try:
+                    maxValues = json.loads(search['maxValues'])
+                    for key in maxValues:
+                        if key not in query:
+                            query[key] = {}
+                        query[key]['$lte'] = maxValues[key]
+                except:
+                    raise RestException('Failed to parse maxValues')
 
         cursor = self.find(query, limit=limit, offset=offset, sort=sort)
         num_matches = cursor.collection.count_documents(query)

--- a/girder/molecules/molecules/molecule.py
+++ b/girder/molecules/molecules/molecule.py
@@ -95,6 +95,12 @@ class Molecule(Resource):
                    paramType='query', required=False)
             .param('creatorId', 'The id of the user that created the molecule',
                    paramType='query', required=False)
+            .jsonParam('minValues', 'A dict of { key: minValue } representing '
+                       'minimum allowable values', requireObject=True,
+                       required=False)
+            .jsonParam('maxValues', 'A dict of { key: maxValue } representing '
+                       'maximum allowable values', requireObject=True,
+                       required=False)
             .pagingParams(defaultSort='_id',
                           defaultSortDir=SortDir.DESCENDING,
                           defaultLimit=25)


### PR DESCRIPTION
In the minValues parameter, one can pass in things like:
```
{ "properties.heavyAtomCount": 4 }
```

and the results will only contain molecules that have at
least 4 heavy atoms. The maxValues parameter can be used
in a similar way.

If both the minValues and maxValues parameters are used, then
the results will satisfy both.

Signed-off-by: Patrick Avery <patrick.avery@kitware.com>