### PR TITLE
Add molecule id to GET /molecules/{id}

### DIFF
--- a/girder/molecules/molecules/molecule.py
+++ b/girder/molecules/molecules/molecule.py
@@ -126,6 +126,7 @@ class Molecule(Resource):
         return self._clean(mol, cjson)
     find_id.description = (
         Description('Get a specific molecule by id')
+        .param('id', 'The id of the molecule', paramType='path')
         .param('cjson', 'Attach the cjson data of the molecule to the response (Default: true)', paramType='query', required=False)
     )
 


### PR DESCRIPTION
This something I've been meaning to add for a while.
It must be present in order for the "id" to show up
in the interactive web API.