### PR TITLE
Allow use of molecules query in GET /molecules

### DIFF
--- a/girder/molecules/molecules/molecule.py
+++ b/girder/molecules/molecules/molecule.py
@@ -432,8 +432,13 @@ class Molecule(Resource):
             except query.InvalidQuery:
                 raise RestException('Invalid query', 400)
 
-            cursor = MoleculeModel().find(query=mongo_query,
-                                          fields=['_id', 'inchikey', 'name'],
+            fields = [
+              'inchikey',
+              'smiles',
+              'properties',
+              'name'
+            ]
+            cursor = MoleculeModel().find(query=mongo_query, fields=fields,
                                           limit=limit, offset=offset,
                                           sort=sort)
             mols = [x for x in cursor]

--- a/girder/molecules/molecules/molecule.py
+++ b/girder/molecules/molecules/molecule.py
@@ -103,6 +103,9 @@ class Molecule(Resource):
             .jsonParam('maxValues', 'A dict of { key: maxValue } representing '
                        'maximum allowable values', requireObject=True,
                        required=False)
+            .param('queryString', 'The query string to use for this search '
+                                  '(supercedes all other search parameters)',
+                   paramType='query', required=False)
             .pagingParams(defaultSort='_id',
                           defaultSortDir=SortDir.DESCENDING,
                           defaultLimit=25)


### PR DESCRIPTION
The molecules query is being added to GET /molecules so that we can use 
it in oc-web-components without having to add logic that determines
whether to use GET /molecules or GET /molecules/search.

If the molecules query ("queryString") parameter is present, then all 
other search parameters will be ignored.