### PR TITLE
Generate SVG image asynchronously

### DIFF
--- a/girder/molecules/molecules/molecule.py
+++ b/girder/molecules/molecules/molecule.py
@@ -21,7 +21,7 @@ from . import chemspider
 from . import query
 from . import semantic
 from . import constants
-from molecules.utilities import generate_3d_coords_async
+from molecules.utilities import async_jobs
 from molecules.utilities.molecules import create_molecule
 from molecules.utilities.pagination import parse_pagination_params
 from molecules.utilities.pagination import search_results_dict
@@ -506,5 +506,5 @@ class Molecule(Resource):
 
         user = self.getCurrentUser()
 
-        generate_3d_coords_async.schedule_3d_coords_gen(mol, user)
+        async_jobs.schedule_3d_coords_gen(mol, user)
         return self._clean(mol)

--- a/girder/molecules/molecules/utilities/async_jobs.py
+++ b/girder/molecules/molecules/utilities/async_jobs.py
@@ -29,10 +29,10 @@ def schedule_3d_coords_gen(mol, user):
         'smiles': smiles
     }
     events.bind('jobs.job.update.after', inchikey,
-                callback_factory(inchikey, user))
+                callback_factory_3d_coords_gen(inchikey, user))
 
     job = Job().createLocalJob(
-        module='molecules.utilities.generate_3d_coords_async',
+        module='molecules.utilities.async_jobs',
         title='Generate 3d coordinates for SMILES: %s' % smiles,
         user=user, type='molecules.generate_3d_coords', public=False,
         function='_run_3d_coords_gen',
@@ -64,7 +64,7 @@ def _run_3d_coords_gen(job):
         raise
 
 
-def callback_factory(inchikey, user):
+def callback_factory_3d_coords_gen(inchikey, user):
 
     def callback(event):
         job = event.info['job']
@@ -96,6 +96,84 @@ def callback_factory(inchikey, user):
             except requests.ConnectionError:
                 print(TerminalColor.warning('WARNING: Couldn\'t '
                                             'connect to Jena.'))
+
+        if job['status'] in [SUCCESS, ERROR, CANCELED]:
+            events.unbind('jobs.job.update.after', inchikey)
+
+        return
+
+    return callback
+
+
+def schedule_svg_gen(mol, user):
+    mol['generating_svg'] = True
+
+    # We only need a couple of entries for the job
+    inchikey = mol['inchikey']
+    smiles = mol['smiles']
+    job_mol = {
+        'inchikey': inchikey,
+        'smiles': smiles
+    }
+    events.bind('jobs.job.update.after', inchikey,
+                callback_factory_svg_gen(inchikey, user))
+
+    job = Job().createLocalJob(
+        module='molecules.utilities.async_jobs',
+        title='Generate SVG for SMILES: %s' % smiles,
+        user=user, type='molecules.generate_svg', public=False,
+        function='_run_svg_gen',
+        kwargs={
+            'mol': job_mol
+        },
+        asynchronous=True)
+    Job().scheduleJob(job)
+    return job
+
+
+def _run_svg_gen(job):
+    jobModel = Job()
+    jobModel.updateJob(job, status=JobStatus.RUNNING)
+
+    try:
+        mol = job['kwargs']['mol']
+        smiles = mol['smiles']
+        svg_data = openbabel.from_smiles(smiles, 'svg')[0]
+        job['kwargs']['svg'] = svg_data
+        log = 'Finished generating svg for %s.' % smiles
+        jobModel.updateJob(job, status=JobStatus.SUCCESS, log=log)
+    except Exception:
+        t, val, tb = sys.exc_info()
+        log = '%s: %s\n%s' % (t.__name__, repr(val), traceback.extract_tb(tb))
+        jobModel.updateJob(job, status=JobStatus.ERROR, log=log)
+        raise
+
+
+def callback_factory_svg_gen(inchikey, user):
+
+    def callback(event):
+        job = event.info['job']
+
+        kwargs = job['kwargs']
+        if 'mol' not in kwargs or kwargs['mol'].get('inchikey') != inchikey:
+            return
+
+        SUCCESS = JobStatus.SUCCESS
+        ERROR = JobStatus.ERROR
+        CANCELED = JobStatus.CANCELED
+
+        if job['status'] == SUCCESS:
+            query = {
+                'inchikey': inchikey
+            }
+            updates = {}
+            updates.setdefault('$set', {})['svg'] = kwargs.get('svg')
+            updates.setdefault('$unset', {})['generating_svg'] = ''
+
+            update_result = super(MoleculeModel,
+                                  MoleculeModel()).update(query, updates)
+            if update_result.matched_count == 0:
+                raise ValidationException('Invalid inchikey (%s)' % inchikey)
 
         if job['status'] in [SUCCESS, ERROR, CANCELED]:
             events.unbind('jobs.job.update.after', inchikey)

--- a/girder/molecules/molecules/utilities/molecules.py
+++ b/girder/molecules/molecules/utilities/molecules.py
@@ -10,7 +10,7 @@ from molecules.models.molecule import Molecule as MoleculeModel
 from girder.constants import TerminalColor
 from girder.api.rest import RestException
 
-from .generate_3d_coords_async import schedule_3d_coords_gen
+from .async_jobs import schedule_3d_coords_gen, schedule_svg_gen
 from .whitelist_cjson import whitelist_cjson
 
 openbabel_2d_formats = [
@@ -66,18 +66,17 @@ def create_molecule(data_str, input_format, user, public, gen3d=True,
         for i in range(0, int(len(pieces) / 2)):
             atomCounts[pieces[2 * i]] = int(pieces[2 * i + 1])
 
-        # Generate an svg file for an image
-        svg_data = openbabel.to_svg(smiles, smiles_format)
-
         mol_dict = {
             'inchi': inchi,
             'inchikey': inchikey,
             'smiles': smiles,
             'properties': props,
             'atomCounts': atomCounts,
-            'svg': svg_data,
             'provenance': provenance
         }
+
+        # Generate an svg file for an image
+        schedule_svg_gen(mol_dict, user)
 
         # Set a name if we find one
         name = chemspider.find_common_name(inchikey)


### PR DESCRIPTION
Generating an SVG image can take a long time for big molecules
(sometimes, more than 1 minute).

Generating it asynchronously should, in theory, be a nice improvement
to server performance. However, the server is still unresponsive while
it is generating the SVG image asynchronously.

Perhaps Open Babel is not releasing the python GIL when it runs the SVG
generation code.

Signed-off-by: Patrick Avery <patrick.avery@kitware.com>