### PR TITLE
When generating inchi, do not convert to xyz first

### DIFF
--- a/flask/openbabel/src/openbabel_api.py
+++ b/flask/openbabel/src/openbabel_api.py
@@ -54,19 +54,11 @@ def to_inchi(str_data, in_format):
     mol = OBMol()
     conv = OBConversion()
     conv.SetInFormat(in_format)
-    # Hackish for now, convert to xyz first...
-    conv.SetOutFormat('xyz')
     conv.ReadString(mol, str_data)
-    xyz = conv.WriteString(mol)
-
-    # Now convert to inchi and inchikey.
-    mol = OBMol()
-    conv.SetInFormat('xyz')
-    conv.ReadString(mol, xyz)
 
     conv.SetOutFormat('inchi')
     inchi = conv.WriteString(mol).rstrip()
-    conv.SetOptions("K", conv.OUTOPTIONS)
+    conv.SetOptions('K', conv.OUTOPTIONS)
     inchikey = conv.WriteString(mol).rstrip()
 
     return (inchi, inchikey)

--- a/girder/molecules/plugin_tests/molecules_test.py
+++ b/girder/molecules/plugin_tests/molecules_test.py
@@ -49,6 +49,8 @@ def test_create_molecule_xyz(server, user):
     assert 'inchikey' in mol
     assert 'smiles' in mol
     assert mol['smiles'] == 'CC'
+    assert mol['inchi'] == 'InChI=1S/C2H6/c1-2/h1-2H3'
+    assert mol['inchikey'] == 'OTMSDBZUPAUEDD-UHFFFAOYSA-N'
 
     # Double check and make sure it exists
     id = mol['_id']
@@ -99,6 +101,8 @@ def test_create_molecule_file_id(server, user, fsAssetstore, make_girder_file):
     assert 'inchikey' in mol
     assert 'smiles' in mol
     assert mol['smiles'] == 'CC'
+    assert mol['inchi'] == 'InChI=1S/C2H6/c1-2/h1-2H3'
+    assert mol['inchikey'] == 'OTMSDBZUPAUEDD-UHFFFAOYSA-N'
     assert 'properties' in mol
     assert 'formula' in mol['properties']
     assert mol['properties']['formula'] == 'C2H6'
@@ -152,6 +156,8 @@ def test_create_molecule_inchi(server, user):
     assert 'inchikey' in mol
     assert 'smiles' in mol
     assert mol['smiles'] == 'O'
+    assert mol['inchi'] == 'InChI=1S/H2O/h1H2'
+    assert mol['inchikey'] == 'XLYOFNOQVPJJNP-UHFFFAOYSA-N'
     assert 'properties' in mol
     assert 'formula' in mol['properties']
     assert mol['properties']['formula'] == 'H2O'
@@ -205,6 +211,8 @@ def test_create_molecule_smiles(server, user):
     assert 'inchikey' in mol
     assert 'smiles' in mol
     assert mol['smiles'] == 'O'
+    assert mol['inchi'] == 'InChI=1S/H2O/h1H2'
+    assert mol['inchikey'] == 'XLYOFNOQVPJJNP-UHFFFAOYSA-N'
     assert 'properties' in mol
     assert 'formula' in mol['properties']
     assert mol['properties']['formula'] == 'H2O'


### PR DESCRIPTION
Converting to xyz has potentially been causing some issues with the
inchi generation. Perhaps it is because the molecule loses the
connectivity and needs to perceive it again - and all atoms get
placed at (0, 0, 0), so bond perception may not be working.

For instance, if we create an inchi from ethane, CC, but we convert
to xyz first, it places both carbon atoms at (0, 0, 0), and only
four hydrogen atoms are added around the two carbon atoms that are
sitting on top of each other. It produces this inchi and inchikey:
```
InChI=1S/2CH4/h2*1H4
CREMABGTGYGIQB-UHFFFAOYSA-N
```

Instead of what appears to be the correct inchi and inchikey:
```
InChI=1S/C2H6/c1-2/h1-2H3
OTMSDBZUPAUEDD-UHFFFAOYSA-N
```

Skipping the xyz conversion seems to fix the issue, and we get the
correct inchi.

However, we should perhaps test this a little more and make sure it
doesn't break anything.