### PR TITLE
Remove molecules GET min/max values from interface

### DIFF
--- a/girder/molecules/molecules/models/molecule.py
+++ b/girder/molecules/molecules/models/molecule.py
@@ -60,26 +60,6 @@ class Molecule(AccessControlledModel):
             if 'creatorId' in search:
                 query['creatorId'] = ObjectId(search['creatorId'])
 
-            if 'minValues' in search:
-                try:
-                    minValues = json.loads(search['minValues'])
-                    for key in minValues:
-                        if key not in query:
-                            query[key] = {}
-                        query[key]['$gte'] = minValues[key]
-                except:
-                    raise RestException('Failed to parse minValues')
-
-            if 'maxValues' in search:
-                try:
-                    maxValues = json.loads(search['maxValues'])
-                    for key in maxValues:
-                        if key not in query:
-                            query[key] = {}
-                        query[key]['$lte'] = maxValues[key]
-                except:
-                    raise RestException('Failed to parse maxValues')
-
         fields = [
           'inchikey',
           'smiles',

--- a/girder/molecules/molecules/molecule.py
+++ b/girder/molecules/molecules/molecule.py
@@ -97,12 +97,6 @@ class Molecule(Resource):
                    paramType='query', required=False)
             .param('creatorId', 'The id of the user that created the molecule',
                    paramType='query', required=False)
-            .jsonParam('minValues', 'A dict of { key: minValue } representing '
-                       'minimum allowable values', requireObject=True,
-                       required=False)
-            .jsonParam('maxValues', 'A dict of { key: maxValue } representing '
-                       'maximum allowable values', requireObject=True,
-                       required=False)
             .param('queryString', 'The query string to use for this search '
                                   '(supercedes all other search parameters)',
                    paramType='query', required=False)


### PR DESCRIPTION
These are not actually used anywhere, and we decided to start
using the mongochem query features to do this kind of thing. Thus,
they are not necessary.