### PR TITLE
Hash input params on server for calc search

### DIFF
--- a/girder/molecules/molecules/calculation.py
+++ b/girder/molecules/molecules/calculation.py
@@ -390,7 +390,7 @@ class Calculation(Resource):
         Description('Search for particular calculation')
         .param('moleculeId', 'The molecule ID linked to this calculation', required=False)
         .param('imageName', 'The name of the Docker image that run this calculation', required=False)
-        .param('inputParameters', 'Json string of the input parameters. May be in percent encoding.', required=False)
+        .param('inputParameters', 'JSON string of the input parameters. May be in percent encoding.', required=False)
         .param('inputGeometryHash', 'The hash of the input geometry.', required=False)
         .param('name', 'The name of the molecule', paramType='query',
                    required=False)

--- a/girder/molecules/molecules/calculation.py
+++ b/girder/molecules/molecules/calculation.py
@@ -390,7 +390,7 @@ class Calculation(Resource):
         Description('Search for particular calculation')
         .param('moleculeId', 'The molecule ID linked to this calculation', required=False)
         .param('imageName', 'The name of the Docker image that run this calculation', required=False)
-        .param('inputParametersHash', 'The hash of the input parameters dictionary.', required=False)
+        .param('inputParameters', 'Json string of the input parameters. May be in percent encoding.', required=False)
         .param('inputGeometryHash', 'The hash of the input geometry.', required=False)
         .param('name', 'The name of the molecule', paramType='query',
                    required=False)
@@ -408,13 +408,13 @@ class Calculation(Resource):
         .pagingParams(defaultSort='_id', defaultSortDir=SortDir.DESCENDING, defaultLimit=25)
     )
     def find_calc(self, moleculeId=None, imageName=None,
-                  inputParametersHash=None, inputGeometryHash=None,
+                  inputParameters=None, inputGeometryHash=None,
                   name=None, inchi=None, inchikey=None, smiles=None,
                   formula=None, creatorId=None, pending=None, limit=None,
                   offset=None, sort=None):
         return CalculationModel().findcal(
             molecule_id=moleculeId, image_name=imageName,
-            input_parameters_hash=inputParametersHash,
+            input_parameters=inputParameters,
             input_geometry_hash=inputGeometryHash, name=name, inchi=inchi,
             inchikey=inchikey, smiles=smiles, formula=formula,
             creator_id=creatorId, pending=pending, limit=limit, offset=offset,

--- a/girder/molecules/molecules/models/calculation.py
+++ b/girder/molecules/molecules/models/calculation.py
@@ -1,6 +1,9 @@
 import sys
+import json
 from jsonschema import validate, ValidationError
 from bson.objectid import ObjectId
+import urllib
+import urllib.parse
 
 from girder.models.model_base import AccessControlledModel, ValidationException
 from girder.utility.model_importer import ModelImporter
@@ -88,7 +91,7 @@ class Calculation(AccessControlledModel):
         return doc
 
     def findcal(self, molecule_id=None, image_name=None,
-                input_parameters_hash=None, input_geometry_hash=None,
+                input_parameters=None, input_geometry_hash=None,
                 name=None, inchi=None, inchikey=None, smiles=None,
                 formula=None, creator_id=None, pending=None, limit=None,
                 offset=None, sort=None, user=None):
@@ -125,8 +128,9 @@ class Calculation(AccessControlledModel):
             query['image.repository'] = repository
             query['image.tag'] = tag
 
-        if input_parameters_hash:
-            query['input.parametersHash'] = input_parameters_hash
+        if input_parameters:
+            input_json = json.loads(urllib.parse.unquote(input_parameters))
+            query['input.parametersHash'] = oc.hash_object(input_json)
 
         if input_geometry_hash:
             query['input.geometryHash'] = input_geometry_hash


### PR DESCRIPTION
This puts the input parameter hashing on the server instead of
on the client side for searching for a calculation. It prevents
clients from having to ensure they hash the input parameters in
the same way that the server does it.

It is intended to send this via url quoted data. However, it
seems to work fine without url quoting also... (probably as long
as there are no percent signs in the string).