### PR TITLE
Add token scopes to @access.user decorators

### DIFF
--- a/girder/app/app/user.py
+++ b/girder/app/app/user.py
@@ -1,6 +1,7 @@
 from girder.api import access
 from girder.api.describe import Description, autoDescribeRoute
 from girder.api.rest import getCurrentUser
+from girder.constants import TokenScope
 from girder.models.model_base import AccessType
 from girder.models.user import User
 
@@ -38,7 +39,7 @@ def get_orcid(user):
     return user.get('orcid')
 
 
-@access.user
+@access.user(scope=TokenScope.DATA_WRITE)
 @autoDescribeRoute(
     Description('Set the orcid of a user.')
     .modelParam('id', 'The ID of the user.', model=User,
@@ -70,7 +71,7 @@ def get_twitter(user):
     return user.get('twitter')
 
 
-@access.user
+@access.user(scope=TokenScope.DATA_WRITE)
 @autoDescribeRoute(
     Description('Set the twitter username of a user.')
     .modelParam('id', 'The ID of the user.', model=User,

--- a/girder/molecules/molecules/calculation.py
+++ b/girder/molecules/molecules/calculation.py
@@ -263,7 +263,7 @@ class Calculation(Resource):
             'The molecular orbital to get the cube for.',
             dataType='string', required=True, paramType='path'))
 
-    @access.user
+    @access.user(scope=TokenScope.DATA_WRITE)
     def create_calc(self, params):
         body = getBodyJson()
         if 'cjson' not in body and ('fileId' not in body or 'format' not in body):
@@ -435,7 +435,7 @@ class Calculation(Resource):
             'The id of calculatino.',
             dataType='string', required=True, paramType='path'))
 
-    @access.user
+    @access.user(scope=TokenScope.DATA_WRITE)
     def delete(self, id, params):
         user = getCurrentUser()
         cal = self._model.load(id, level=AccessType.READ, user=user)
@@ -495,7 +495,7 @@ class Calculation(Resource):
 
         return calculation
 
-    @access.user
+    @access.user(scope=TokenScope.DATA_WRITE)
     @autoDescribeRoute(
         Description('Add notebooks ( file ids ) to molecule.')
         .modelParam('id', 'The calculation id',

--- a/girder/molecules/molecules/molecule.py
+++ b/girder/molecules/molecules/molecule.py
@@ -13,6 +13,7 @@ from girder.api import access
 from girder.constants import AccessType
 from girder.constants import SortDir
 from girder.constants import TerminalColor
+from girder.constants import TokenScope
 from girder.models.file import File
 from girder.utility.model_importer import ModelImporter
 from . import avogadro
@@ -133,7 +134,7 @@ class Molecule(Resource):
         .param('cjson', 'Attach the cjson data of the molecule to the response (Default: true)', paramType='query', required=False)
     )
 
-    @access.user
+    @access.user(scope=TokenScope.DATA_WRITE)
     def create(self, params):
         body = self.getBodyJson()
         user = self.getCurrentUser()
@@ -198,7 +199,7 @@ class Molecule(Resource):
             required=True, paramType='body')
         .errorResponse('Input format not supported.', code=400))
 
-    @access.user
+    @access.user(scope=TokenScope.DATA_WRITE)
     def delete(self, id, params):
         user = self.getCurrentUser()
         mol = MoleculeModel().load(id, user=user, level=AccessType.WRITE)
@@ -214,7 +215,7 @@ class Molecule(Resource):
             .errorResponse()
             .errorResponse('Molecule not found.', 404))
 
-    @access.user
+    @access.user(scope=TokenScope.DATA_WRITE)
     def update(self, id, params):
         user = self.getCurrentUser()
 
@@ -265,7 +266,7 @@ class Molecule(Resource):
             required=True, paramType='body')
             .errorResponse('Molecule not found.', 404))
 
-    @access.user
+    @access.user(scope=TokenScope.DATA_WRITE)
     @autoDescribeRoute(
         Description('Add notebooks ( file ids ) to molecule.')
         .modelParam('id', 'The molecule id',
@@ -278,7 +279,7 @@ class Molecule(Resource):
         if notebooks is not None:
             MoleculeModel().add_notebooks(molecule, notebooks)
 
-    @access.user
+    @access.user(scope=TokenScope.DATA_READ)
     def conversions(self, output_format, params):
         user = self.getCurrentUser()
 
@@ -486,7 +487,7 @@ class Molecule(Resource):
                           defaultSortDir=SortDir.DESCENDING,
                           defaultLimit=25))
 
-    @access.user
+    @access.user(scope=TokenScope.DATA_WRITE)
     @autoDescribeRoute(
             Description('Generate 3D coordinates for a molecule.')
             .modelParam('id', 'The id of the molecule', destName='mol',


### PR DESCRIPTION
This allows api keys that have custom access permissions to
interface with the endpoints.

Fixes: #157