### PR TITLE
Check for exception on asynchronous orbital calculation

### DIFF
--- a/girder/molecules/molecules/calculation.py
+++ b/girder/molecules/molecules/calculation.py
@@ -189,9 +189,6 @@ class Calculation(Resource):
 
     @access.public
     def get_calc_cube(self, id, mo, params):
-        if 'status' in params:
-            raise RestException('Invalid JSON or MO.', params['status'])
-
         orig_mo = mo
         try:
             mo = int(mo)

--- a/girder/molecules/molecules/calculation.py
+++ b/girder/molecules/molecules/calculation.py
@@ -189,6 +189,9 @@ class Calculation(Resource):
 
     @access.public
     def get_calc_cube(self, id, mo, params):
+        if 'status' in params:
+            raise RestException('Invalid JSON or MO.', params['status'])
+
         orig_mo = mo
         try:
             mo = int(mo)
@@ -234,7 +237,7 @@ class Calculation(Resource):
         # This is where the cube gets calculated, should be cached in future.
         if 'async' in params and params['async']:
             async_requests.schedule_orbital_gen(
-                calc['cjson'], mo, id, orig_mo)
+                calc['cjson'], mo, id, orig_mo, self.getCurrentUser())
             calc['cjson']['cube'] = {
                 'dimensions': [0, 0, 0],
                 'scalars': []

--- a/girder/molecules/molecules/utilities/async_requests.py
+++ b/girder/molecules/molecules/utilities/async_requests.py
@@ -179,7 +179,10 @@ def _finish_orbital_gen(mo, id, user, orig_mo, future):
         # Create notification to indicate cube can be retrieved now
         data = {'id': id, 'mo': orig_mo}
     else:
-        data = {'id': id, 'mo': orig_mo, 'error': resp.status_code}
+        data = {
+            'id': id,
+            'mo': orig_mo,
+            'error': 'Status code ' + str(resp.status_code) + ': Orbital could not be calculated.'}
 
     Notification().createNotification(
         type='cube.status',


### PR DESCRIPTION
If the ansynchronous orbital calculation returns a status other than 200, update
the client notification and raise an exception on the next call to the endpoint.

Signed-off-by: Brianna Major <brianna.major@kitware.com>