### PR TITLE
Save optimized geometry IDs in calculations

### DIFF
--- a/girder/molecules/molecules/calculation.py
+++ b/girder/molecules/molecules/calculation.py
@@ -397,8 +397,10 @@ class Calculation(Resource):
             provenanceType = 'calculation'
             provenanceId = calculation.get('_id')
             # The cjson will be whitelisted
-            GeometryModel().create(getCurrentUser(), moleculeId, cjson,
-                                   provenanceType, provenanceId)
+            geometry = GeometryModel().create(getCurrentUser(), moleculeId,
+                                              cjson, provenanceType,
+                                              provenanceId)
+            calculation['optimizedGeometryId'] = geometry.get('_id')
 
         return CalculationModel().save(calculation)
 


### PR DESCRIPTION
When an optimization calculation is performed, and a new geometry is
generated as a result, save the optimized geometry ID in the calculation
as "optimizedGeometryId".

"geometryId" is not used here because, if a specific geometry was chosen
as input for the calculation, "geometryId" is the ID of that input
geometry.

The optimizedGeometryId of a calculation can be obtained through the
GET "/calculations/{id}" end point.

An already present feature that goes along with this: for geometries that
were produced by an optimization calculation, the provenanceType is
"calculation", and the provenanceId is the ID of the optimization
calculation it came from. Thus, if a chain of optimizations were
performed to produce a geometry, one can back-track to the original
calculation/geometry that the chain started with.