### PR TITLE
Upgrade openbabel to 3.0.0

### DIFF
--- a/docker/flask/openbabel/Dockerfile
+++ b/docker/flask/openbabel/Dockerfile
@@ -1,16 +1,11 @@
-FROM python:3.7-slim
+FROM continuumio/miniconda3:4.7.12
 
-RUN apt-get update -y
-RUN apt-get install -y \
-  build-essential \
-  pkg-config \
-  libopenbabel-dev \
-  swig
+RUN conda install -c conda-forge openbabel=3.0.0 -y
 
-RUN pip3 install gunicorn
+RUN pip install gunicorn
 
 COPY flask/openbabel/requirements.txt /app/
-RUN pip3 install -r /app/requirements.txt
+RUN pip install -r /app/requirements.txt
 
 COPY flask/openbabel/src/* /app/
 

--- a/flask/openbabel/README.md
+++ b/flask/openbabel/README.md
@@ -1,8 +1,9 @@
 Running the Open Babel Flask Server Locally
 ===========================================
 
-To run the Open Babel flask server locally, install the
-requirements.txt file and start the server like so:
+To run the Open Babel flask server locally, install openbabel>=3.0.0
+via conda (in the conda-forge channel), pip, or a local build, then
+install the requirements.txt file and start the server like so:
 ```
 pip install -r requirements.txt
 python src/server.py

--- a/flask/openbabel/requirements.txt
+++ b/flask/openbabel/requirements.txt
@@ -1,2 +1,1 @@
 Flask
-openbabel==2.4.1

--- a/flask/openbabel/src/openbabel_api.py
+++ b/flask/openbabel/src/openbabel_api.py
@@ -1,6 +1,4 @@
-from openbabel import OBMol, OBConversion
-
-import pybel
+from openbabel import OBMol, OBConversion, pybel
 
 import re
 


### PR DESCRIPTION
Since Ubuntu's `libopenbabel-dev` and the openbabel Linux wheels on
PyPI are not up-to-date, we moved to installing openbabel via conda
in the conda-forge channel.

The only migration change I could find is that we need to import pybel
via `from openbabel import pybel` instead of just `import pybel`.

Using the new image, I ran the pytests, and tried out all of the
notebooks, and I did not notice anything unusual. But it might be good
for someone else to double-check.

The handling of implicit hydrogens has changed a little bit, which may
affect us somewhere, but I did not immediately see any differences in
our examples.

Migration instructions can be found [here](https://open-babel.readthedocs.io/en/latest/UseTheLibrary/migration.html).