### PR TITLE
Add forcefield and steps options for gen3d

### DIFF
--- a/flask/openbabel/src/openbabel_api.py
+++ b/flask/openbabel/src/openbabel_api.py
@@ -16,7 +16,8 @@ def validate_start_of_inchi(inchi):
 
 # gen3d should be true for 2D input formats such as inchi or smiles
 def convert_str(str_data, in_format, out_format, gen3d=False,
-                add_hydrogens=False, perceive_bonds=False, out_options=None):
+                add_hydrogens=False, perceive_bonds=False, out_options=None,
+                gen3d_forcefield='mmff94', gen3d_steps=100):
 
     # Make sure that the start of InChI is valid before passing it to
     # Open Babel, or Open Babel will crash the server.
@@ -38,7 +39,7 @@ def convert_str(str_data, in_format, out_format, gen3d=False,
     if gen3d:
         # Generate 3D coordinates for the input
         mol = pybel.Molecule(obMol)
-        mol.make3D()
+        mol.make3D(gen3d_forcefield, gen3d_steps)
 
     if perceive_bonds:
         obMol.ConnectTheDots()

--- a/flask/openbabel/src/server.py
+++ b/flask/openbabel/src/server.py
@@ -55,12 +55,16 @@ def convert(output_format):
         add_hydrogens = json_data.get('addHydrogens', False)
         perceive_bonds = json_data.get('perceiveBonds', False)
         out_options = json_data.get('outOptions', {})
+        gen3d_forcefield = json_data.get('gen3dForcefield', 'mmff94')
+        gen3d_steps = json_data.get('gen3dSteps', 100)
 
         data, mime = openbabel.convert_str(data, input_format, output_format,
                                            gen3d=gen3d,
                                            add_hydrogens=add_hydrogens,
                                            perceive_bonds=perceive_bonds,
-                                           out_options=out_options)
+                                           out_options=out_options,
+                                           gen3d_forcefield=gen3d_forcefield,
+                                           gen3d_steps=gen3d_steps)
     return Response(data, mimetype=mime)
 
 

--- a/girder/molecules/molecules/molecule.py
+++ b/girder/molecules/molecules/molecule.py
@@ -152,6 +152,8 @@ class Molecule(Resource):
         user = self.getCurrentUser()
         public = body.get('public', False)
         gen3d = body.get('generate3D', True)
+        gen3d_forcefield = body.get('gen3dForcefield', 'mmff94')
+        gen3d_steps = body.get('gen3dSteps', 100)
         provenance = body.get('provenance', 'uploaded by user')
         mol = None
         if 'fileId' in body:
@@ -168,7 +170,7 @@ class Molecule(Resource):
                 data_str = f.read().decode()
 
             mol = create_molecule(data_str, input_format, user, public, gen3d,
-                                  provenance)
+                                  provenance, gen3d_forcefield, gen3d_steps)
         elif 'inchi' in body:
             input_format = 'inchi'
             data = body['inchi']
@@ -176,7 +178,7 @@ class Molecule(Resource):
                 data = 'InChI=' + data
 
             mol = create_molecule(data, input_format, user, public, gen3d,
-                                  provenance)
+                                  provenance, gen3d_forcefield, gen3d_steps)
 
         for key in body:
             if key in Molecule.input_formats:
@@ -185,8 +187,8 @@ class Molecule(Resource):
                 # Convert to str if necessary
                 if isinstance(data, dict):
                     data = json.dumps(data)
-                mol = create_molecule(data, input_format,  user, public, gen3d,
-                                      provenance)
+                mol = create_molecule(data, input_format, user, public, gen3d,
+                                      provenance, gen3d_forcefield, gen3d_steps)
                 break
 
         if not mol:
@@ -504,9 +506,13 @@ class Molecule(Resource):
             Description('Generate 3D coordinates for a molecule.')
             .modelParam('id', 'The id of the molecule', destName='mol',
                         level=AccessType.WRITE, model=MoleculeModel)
+            .param('forcefield', 'The force field to use', default='mmff94',
+                   strip=True)
+            .param('steps', 'The number of optimization steps', default='100',
+                   dataType='integer')
             .errorResponse('Molecule not found.', 404)
     )
-    def generate_3d_coords(self, mol):
+    def generate_3d_coords(self, mol, forcefield, steps):
         """Generate 3D coords if not present and not being generated"""
 
         if (MoleculeModel().has_3d_coords(mol) or
@@ -515,7 +521,9 @@ class Molecule(Resource):
 
         user = self.getCurrentUser()
 
-        async_requests.schedule_3d_coords_gen(mol, user)
+        async_requests.schedule_3d_coords_gen(mol, user,
+                                              gen3d_forcefield=forcefield,
+                                              gen3d_steps=steps)
         return self._clean(mol)
 
     @access.public

--- a/girder/molecules/molecules/utilities/async_requests.py
+++ b/girder/molecules/molecules/utilities/async_requests.py
@@ -78,7 +78,8 @@ def _finish_svg_gen(inchikey, user, future):
         raise ValidationException('Invalid inchikey (%s)' % inchikey)
 
 
-def schedule_3d_coords_gen(mol, user, on_complete=None):
+def schedule_3d_coords_gen(mol, user, on_complete=None,
+                           gen3d_forcefield='mmff94', gen3d_steps=100):
     query = {
         '_id': mol['_id']
     }
@@ -100,7 +101,9 @@ def schedule_3d_coords_gen(mol, user, on_complete=None):
     data = {
         'format': 'smi',
         'data': mol['smiles'],
-        'gen3d': True
+        'gen3d': True,
+        'gen3dForcefield': gen3d_forcefield,
+        'gen3dSteps': gen3d_steps
     }
 
     session = FuturesSession()

--- a/girder/molecules/molecules/utilities/molecules.py
+++ b/girder/molecules/molecules/utilities/molecules.py
@@ -31,7 +31,8 @@ openbabel_formats = openbabel_2d_formats + openbabel_3d_formats
 
 
 def create_molecule(data_str, input_format, user, public, gen3d=True,
-                    provenance='uploaded by user'):
+                    provenance='uploaded by user', gen3d_forcefield='mmff94',
+                    gen3d_steps=100):
 
     using_2d_format = (input_format in openbabel_2d_formats)
     inchi_format = 'inchi'
@@ -98,7 +99,9 @@ def create_molecule(data_str, input_format, user, public, gen3d=True,
                 except requests.ConnectionError:
                     print(TerminalColor.warning('WARNING: Couldn\'t connect to Jena.'))
 
-            schedule_3d_coords_gen(mol_dict, user, on_complete=_on_complete)
+            schedule_3d_coords_gen(mol_dict, user, on_complete=_on_complete,
+                                   gen3d_forcefield=gen3d_forcefield,
+                                   gen3d_steps=gen3d_steps)
 
         # Generate an svg file for an image
         schedule_svg_gen(mol_dict, user)


### PR DESCRIPTION
This adds options to choose the forcefield (default: 'mmff94') and
the number of optimization steps (default: 100) when generating 3D
coordinates for a molecule.

In the POST /molecules REST API, the forcefield can be specified with
"gen3dForcefield", and the number of steps can be specified with
"gen3dSteps". In the POST /molecules/{id}/3d REST API, the forcefield
can be specified with the "forcefield" query, and the number of steps
can be specified with the "steps" query.

The previous number of optimization steps was 50. This commit bumps
the default number of optimization steps up to 100, so the molecules
will probably be slightly different than before.