### PR TITLE
Allow user to pass in name or wikipedia link

### DIFF
--- a/girder/molecules/molecules/calculation.py
+++ b/girder/molecules/molecules/calculation.py
@@ -233,7 +233,7 @@ class Calculation(Resource):
         calc = self._model.load(id, fields=fields, force=True)
 
         # This is where the cube gets calculated, should be cached in future.
-        if 'async' in params and params['async']:
+        if ('async' in params) and (params['async']):
             async_requests.schedule_orbital_gen(
                 calc['cjson'], mo, id, orig_mo, self.getCurrentUser())
             calc['cjson']['cube'] = {
@@ -280,6 +280,8 @@ class Calculation(Resource):
         notebooks = body.get('notebooks', [])
         image = body.get('image')
         input_parameters = body.get('input', {}).get('parameters')
+        if input_parameters is None:
+            input_parameters = body.get('inputParameters', {})
         file_id = None
         file_format = body.get('format', 'cjson')
 
@@ -289,7 +291,7 @@ class Calculation(Resource):
             cjson = self._file_to_cjson(file, file_format)
 
         if molecule_id is None:
-            mol = create_molecule(json.dumps(cjson), 'cjson', user, public)
+            mol = create_molecule(json.dumps(cjson), 'cjson', user, public, parameters=input_parameters)
             molecule_id = mol['_id']
 
         calc = CalculationModel().create_cjson(user, cjson, props, molecule_id,

--- a/girder/molecules/molecules/molecule.py
+++ b/girder/molecules/molecules/molecule.py
@@ -168,7 +168,8 @@ class Molecule(Resource):
                 data_str = f.read().decode()
 
             mol = create_molecule(data_str, input_format, user, public, gen3d,
-                                  provenance)
+                              provenance, body)
+
         elif 'inchi' in body:
             input_format = 'inchi'
             data = body['inchi']
@@ -176,7 +177,7 @@ class Molecule(Resource):
                 data = 'InChI=' + data
 
             mol = create_molecule(data, input_format, user, public, gen3d,
-                                  provenance)
+                              provenance, body)
 
         for key in body:
             if key in Molecule.input_formats:
@@ -186,7 +187,7 @@ class Molecule(Resource):
                 if isinstance(data, dict):
                     data = json.dumps(data)
                 mol = create_molecule(data, input_format,  user, public, gen3d,
-                                      provenance)
+                                      provenance, body)
                 break
 
         if not mol:

--- a/girder/molecules/molecules/utilities/molecules.py
+++ b/girder/molecules/molecules/utilities/molecules.py
@@ -89,8 +89,8 @@ def create_molecule(data_str, input_format, user, public, gen3d=True,
             mol_dict['name'] = name
 
         # Set a wikipedia link if one is provided
-        if 'wikipedia' in parameters:
-            mol_dict['wiki'] = parameters['wikipedia']
+        if 'wikipediaUrl' in parameters:
+            mol_dict['wikipediaUrl'] = parameters['wikipediaUrl']
 
         if not using_2d_format:
             # The cjson should already be a local variable

--- a/girder/molecules/molecules/utilities/molecules.py
+++ b/girder/molecules/molecules/utilities/molecules.py
@@ -31,7 +31,7 @@ openbabel_formats = openbabel_2d_formats + openbabel_3d_formats
 
 
 def create_molecule(data_str, input_format, user, public, gen3d=True,
-                    provenance='uploaded by user'):
+                    provenance='uploaded by user', parameters={}):
 
     using_2d_format = (input_format in openbabel_2d_formats)
     inchi_format = 'inchi'
@@ -79,10 +79,17 @@ def create_molecule(data_str, input_format, user, public, gen3d=True,
             'provenance': provenance
         }
 
-        # Set a name if we find one
-        name = chemspider.find_common_name(inchikey)
+        # Set a name if we find one or one is provided
+        if 'name' in parameters:
+            name = parameters['name']
+        else:
+            name = chemspider.find_common_name(inchikey)
         if name is not None:
             mol_dict['name'] = name
+
+        # Set a wikipedia link if one is provided
+        if 'wikipedia' in parameters:
+            mol_dict['wiki'] = parameters['wikipedia']
 
         if not using_2d_format:
             # The cjson should already be a local variable


### PR DESCRIPTION
If a 'name' or 'wikipedia' field are passed in via the body of a molecule those fields will be set. 

If 'name' or 'wikipedia' are included in the input parameters of a calculation and the molecule does not yet exist those fields will be set upon molecule creation. If the molecule already exists the fields are ignored.