### PR TITLE
Convert steps to int for generating 3D coordinates

### DIFF
--- a/girder/molecules/molecules/molecule.py
+++ b/girder/molecules/molecules/molecule.py
@@ -519,6 +519,11 @@ class Molecule(Resource):
                 mol.get('generating_3d_coords', False)):
             return self._clean(mol)
 
+        try:
+            steps = int(steps)
+        except ValueError:
+            raise RestException(str(steps) + ' is not a number')
+
         user = self.getCurrentUser()
 
         async_requests.schedule_3d_coords_gen(mol, user,


### PR DESCRIPTION
For the end point POST /molecules/{id}/3d, the steps is a query, and
is thus treated as a string. Convert it to an int before calling
schedule_3d_coords_gen() with it.

This was not causing a problem with the web API since it the web API
automatically converts it to an int. However, it is a problem for
calling this end point in other contexts, including openchemistrypy. This
PR fixes the issue.