### PR TITLE
Add example of setting gen3d options

### DIFF
--- a/girder/notebooks/notebooks/notebooks/MultipleCalcs.ipynb
+++ b/girder/notebooks/notebooks/notebooks/MultipleCalcs.ipynb
@@ -190,6 +190,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Alternatively, 3D coordinates may also be generated manually. If this is done, the forcefield options may also be passed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mols[1].structure.generate_3d(forcefield='uff', steps=150)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# Specifying the Type for Multiple Calculations"
    ]
   },


### PR DESCRIPTION
This example illustrates the ability to select the force field
and the number of steps when generating 3D coordinates.

Note also that the arguments `gen3d_forcefield` and `gen3d_steps`
may be passed to `oc.import_structure()` for 3D coordinate generation
when importing line formats like SMILES.

This is an example of using the features found in OpenChemistry/openchemistrypy#96