### PR TITLE
Return None when 3D output requested for 0D mol

### DIFF
--- a/girder/molecules/molecules/molecule.py
+++ b/girder/molecules/molecules/molecule.py
@@ -388,8 +388,8 @@ class Molecule(Resource):
         if output_format in Molecule.output_formats_3d:
             # If it is a 3d output format, cjson is required
             if 'cjson' not in molecule:
-                raise RestException('Molecule does not have 3D coordinates.',
-                                    404)
+                # Returning None implies that there are no 3D coordinates
+                return
 
             data = json.dumps(molecule['cjson'])
             if output_format != 'cjson':


### PR DESCRIPTION
If a user requests for 3D output of a molecule that does not have 3D
coordinates, return 'None' rather than raising an exception, as was
previously done.

This is done to address [this comment](https://github.com/OpenChemistry/openchemistrypy/pull/96/files/a83a1334301d930dac0c1fcfef31072c8ccb2bcc#r362954723) in openchemistry/openchemistrypy#96.