### PR TITLE
Make findmol -> find_molecule - fix inconsistency

### DIFF
--- a/girder/molecules/molecules/models/calculation.py
+++ b/girder/molecules/molecules/models/calculation.py
@@ -120,7 +120,7 @@ class Calculation(AccessControlledModel):
             if formula:
                 params['formula'] = formula
 
-            molecules = MoleculeModel().findmol(params)['results']
+            molecules = MoleculeModel().find_molecule(params)['results']
             molecule_ids = [molecule['_id'] for molecule in molecules]
             query['moleculeId'] = {'$in': molecule_ids}
 

--- a/girder/molecules/molecules/models/molecule.py
+++ b/girder/molecules/molecules/models/molecule.py
@@ -28,7 +28,7 @@ class Molecule(AccessControlledModel):
     def validate(self, doc):
         return doc
 
-    def findmol(self, search = None):
+    def find_molecule(self, search = None):
         limit, offset, sort = parse_pagination_params(search)
 
         if search is None:

--- a/girder/molecules/molecules/molecule.py
+++ b/girder/molecules/molecules/molecule.py
@@ -94,7 +94,7 @@ class Molecule(Resource):
 
     @access.public
     def find(self, params):
-        return MoleculeModel().findmol(params)
+        return MoleculeModel().find_molecule(params)
     find.description = (
             Description('Find a molecule.')
             .param('name', 'The name of the molecule', paramType='query',
@@ -469,7 +469,7 @@ class Molecule(Resource):
 
         elif formula:
             # Search using formula
-            return MoleculeModel().findmol(params)
+            return MoleculeModel().find_molecule(params)
 
         elif cactus:
             if getCurrentUser() is None:


### PR DESCRIPTION
The Girder base class already uses the "find" name that would have been
used more naturally, so at least make the name conform to our coding
standards using snake_case and make it a little more explicitly
molecule.