### PR TITLE
Fix GET /calculations with a geometry ID

### DIFF
--- a/girder/molecules/molecules/models/calculation.py
+++ b/girder/molecules/molecules/models/calculation.py
@@ -125,7 +125,8 @@ class Calculation(AccessControlledModel):
             query['moleculeId'] = {'$in': molecule_ids}
 
         if geometry_id:
-            query['geometryId'] = ObjectId(geometry_id)
+            # This is currently not being stored as an ObjectId
+            query['geometryId'] = geometry_id
 
         if image_name:
             repository, tag = oc.parse_image_name(image_name)


### PR DESCRIPTION
The geometry ID is not being stored as an ObjectId currently. Thus,
if we try to query it as an ObjectId, we find no results. Fix this
by removing the ObjectId conversion.

Another alternative to fix this is to convert the geometry ID into
an ObjectId when it gets saved on the calculation. Let me know 
if that is preferred.