### PR TITLE
Have models default to being public

### DIFF
--- a/girder/molecules/molecules/calculation.py
+++ b/girder/molecules/molecules/calculation.py
@@ -276,7 +276,7 @@ class Calculation(Resource):
         props = body.get('properties', {})
         molecule_id = body.get('moleculeId', None)
         geometry_id = body.get('geometryId', None)
-        public = body.get('public', False)
+        public = body.get('public', True)
         notebooks = body.get('notebooks', [])
         image = body.get('image')
         input_parameters = body.get('input', {}).get('parameters')

--- a/girder/molecules/molecules/models/calculation.py
+++ b/girder/molecules/molecules/models/calculation.py
@@ -169,7 +169,7 @@ class Calculation(AccessControlledModel):
 
     def create_cjson(self, user, cjson, props, molecule_id=None,
                      geometry_id=None, image=None, input_parameters=None,
-                     file_id = None, public=False, notebooks=None):
+                     file_id = None, public=True, notebooks=None):
         if notebooks is None:
             notebooks = []
 

--- a/girder/molecules/molecules/models/geometry.py
+++ b/girder/molecules/molecules/models/geometry.py
@@ -30,7 +30,7 @@ class Geometry(AccessControlledModel):
         return doc
 
     def create(self, user, moleculeId, cjson, provenanceType=None,
-               provenanceId=None, public=False):
+               provenanceId=None, public=True):
 
         # We will whitelist the cjson to only include the geometry parts
         geometry = {

--- a/girder/molecules/molecules/models/molecule.py
+++ b/girder/molecules/molecules/models/molecule.py
@@ -86,7 +86,7 @@ class Molecule(AccessControlledModel):
         mol = self.findOne(query)
         return mol
 
-    def create(self, user, mol, public=False):
+    def create(self, user, mol, public=True):
 
         if 'properties' not in mol and mol.get('cjson') is not None:
             props = avogadro.molecule_properties(json.dumps(mol.get('cjson')), 'cjson')

--- a/girder/molecules/molecules/molecule.py
+++ b/girder/molecules/molecules/molecule.py
@@ -150,7 +150,7 @@ class Molecule(Resource):
     def create(self, params):
         body = self.getBodyJson()
         user = self.getCurrentUser()
-        public = body.get('public', False)
+        public = body.get('public', True)
         gen3d = body.get('generate3D', True)
         gen3d_forcefield = body.get('gen3dForcefield', 'mmff94')
         gen3d_steps = body.get('gen3dSteps', 100)


### PR DESCRIPTION
This makes molecules, calculations, and geometries default to
being public, rather than private.

Fixes: #155