### PR TITLE
Add a single endpoint to launch taskflows

### DIFF
--- a/girder/app/app/__init__.py
+++ b/girder/app/app/__init__.py
@@ -2,6 +2,7 @@ from .configuration import Configuration
 from girder.utility import setting_utilities
 from .constants import Features, Branding, Deployment
 
+from .launch_taskflow import launch_taskflow
 from .user import get_orcid, set_orcid, get_twitter, set_twitter
 
 from girder.plugin import GirderPlugin
@@ -30,3 +31,6 @@ class AppPlugin(GirderPlugin):
         info['apiRoot'].user.route('POST', (':id', 'orcid'), set_orcid)
         info['apiRoot'].user.route('GET', (':id', 'twitter'), get_twitter)
         info['apiRoot'].user.route('POST', (':id', 'twitter'), set_twitter)
+
+        # Launch a taskflow with a single endpoint
+        info['apiRoot'].queues.route('POST', ('launchtaskflow',), launch_taskflow)

--- a/girder/app/app/__init__.py
+++ b/girder/app/app/__init__.py
@@ -3,7 +3,7 @@ from girder.api.rest import Resource
 from girder.utility import setting_utilities
 from .constants import Features, Branding, Deployment
 
-from .launch_taskflow import launch_taskflow
+from .launch_taskflow import launch_taskflow_endpoint
 from .user import get_orcid, set_orcid, get_twitter, set_twitter
 
 from girder.plugin import GirderPlugin
@@ -35,4 +35,5 @@ class AppPlugin(GirderPlugin):
 
         # Launch a taskflow with a single endpoint
         info['apiRoot'].launch_taskflow = Resource()
-        info['apiRoot'].launch_taskflow.route('POST', ('launch',), launch_taskflow)
+        info['apiRoot'].launch_taskflow.route('POST', ('launch',),
+                                              launch_taskflow_endpoint)

--- a/girder/app/app/__init__.py
+++ b/girder/app/app/__init__.py
@@ -1,4 +1,5 @@
 from .configuration import Configuration
+from girder.api.rest import Resource
 from girder.utility import setting_utilities
 from .constants import Features, Branding, Deployment
 
@@ -33,4 +34,5 @@ class AppPlugin(GirderPlugin):
         info['apiRoot'].user.route('POST', (':id', 'twitter'), set_twitter)
 
         # Launch a taskflow with a single endpoint
-        info['apiRoot'].queues.route('POST', ('launchtaskflow',), launch_taskflow)
+        info['apiRoot'].launch_taskflow = Resource()
+        info['apiRoot'].launch_taskflow.route('POST', ('launch',), launch_taskflow)

--- a/girder/app/app/launch_taskflow.py
+++ b/girder/app/app/launch_taskflow.py
@@ -1,0 +1,100 @@
+import os
+import sys
+
+from girder.api import access
+from girder.api.describe import autoDescribeRoute, Description
+from girder.api.rest import getCurrentUser, getBodyJson, RestException
+from girder.constants import TokenScope
+
+from cumulus.taskflow import load_class
+from cumulus_plugin.models.cluster import Cluster as ClusterModel
+from queues.models.queue import Queue as QueueModel, QueueType
+from taskflow.models.taskflow import Taskflow as TaskflowModel
+
+
+@access.user(scope=TokenScope.DATA_WRITE)
+@autoDescribeRoute(
+    Description('Launch a taskflow.')
+    .param('clusterId', 'The cluster ID to use.', required=False)
+    .param('body',
+           'Contains "taskFlowBody" and "taskBody" for the taskflow and task',
+           paramType='body')
+)
+def launch_taskflow(clusterId):
+    user = getCurrentUser()
+    body = getBodyJson()
+
+    # Perform some validation
+    taskFlowBody = body.get('taskFlowBody')
+    if taskFlowBody is None:
+        raise RestException('taskFlowBody is a required key')
+
+    if 'taskFlowClass' not in taskFlowBody:
+        raise RestException('taskFlowClass is required in taskFlowBody')
+
+    taskflow_class = taskFlowBody['taskFlowClass']
+
+    # Check that we can load the taskflow class
+    try:
+        load_class(taskflow_class)
+    except Exception as ex:
+        msg = 'Unable to load taskflow class: %s (%s)' % \
+              (taskflow_class, ex)
+        raise RestException(msg, 400)
+
+    # Set up the task body
+    taskBody = body.get('taskBody', {})
+    if 'cluster' not in taskBody:
+        # Make a cluster
+        taskBody['cluster'] = create_cluster_object(clusterId, user)
+
+    if 'container' not in taskBody:
+        taskBody['container'] = 'docker'
+
+    # Load the queue
+    queue = fetch_or_create_queue(user)
+
+    # Create the taskflow
+    taskflow = TaskflowModel().create(user, taskFlowBody)
+
+    # Add it to the queue and start it
+    QueueModel().add(queue, taskflow, taskBody, user)
+    QueueModel().pop(queue, limit=sys.maxsize, user=user)
+
+    return taskflow['_id']
+
+
+def _nersc():
+    return os.environ.get('OC_SITE') == 'NERSC'
+
+
+def fetch_or_create_queue(user):
+    # Fetch or create the queue
+    name = 'oc_queue'
+    queues = list(QueueModel().find(name=name, user=user))
+    if len(queues) > 0:
+        queue = queues[0]
+    else:
+        type = QueueType.FIFO
+        queue = QueueModel().create(name, type_=type, max_running=5, user=user)
+
+    return queue
+
+
+def create_cluster_object(cluster_id=None, user=None):
+    if cluster_id is None and not _nersc():
+        # Get the first cluster we can find
+        clusters = ClusterModel().find_cluster({}, user=user)
+
+        if len(clusters) > 0:
+            cluster_id = clusters[0]['_id']
+        else:
+            raise Exception('Unable to register images, no cluster configured')
+
+    if cluster_id is not None:
+        return {'_id': cluster_id}
+
+    if _nersc():
+        return {'name': 'cori'}
+
+    raise Exception('Failed to configure cluster')

--- a/girder/app/app/launch_taskflow.py
+++ b/girder/app/app/launch_taskflow.py
@@ -19,10 +19,13 @@ from taskflow.models.taskflow import Taskflow as TaskflowModel
            'Contains "taskFlowBody" and "taskBody" for the taskflow and task',
            paramType='body')
 )
-def launch_taskflow():
+def launch_taskflow_endpoint():
     user = getCurrentUser()
     body = getBodyJson()
+    return launch_taskflow(user, body)
 
+
+def launch_taskflow(user, body):
     # Perform some validation
     taskFlowBody = body.get('taskFlowBody')
     if taskFlowBody is None:


### PR DESCRIPTION
Rather than having ~7 restful API calls to launch a single taskflow,
add a single restful API endpoint that takes care of most of the logic.

This single API call optionally takes a clusterId. It will use that
cluster if provided. If not provided one, it will use the first cluster
it can find.

The body of the endpoint should contain two keys:

1. taskFlowBody
2. taskBody

That contain the bodies of the taskflow, and the task, respectively.

Depends on: Kitware/cumulus#362
Fixes: #187 