### PR TITLE
Use "latest" instead of "latest-py3" for girder

### DIFF
--- a/docker/girder/Dockerfile
+++ b/docker/girder/Dockerfile
@@ -1,4 +1,4 @@
-FROM girder/girder:latest-py3
+FROM girder/girder:latest
 
 # Install cumulus
 RUN git clone https://github.com/Kitware/cumulus.git /cumulus && \

--- a/docker/girder/Dockerfile
+++ b/docker/girder/Dockerfile
@@ -1,4 +1,4 @@
-FROM girder/girder:latest
+FROM girder/girder:3.1.0
 
 # Install cumulus
 RUN git clone https://github.com/Kitware/cumulus.git /cumulus && \


### PR DESCRIPTION
Girder [does not support the "latest-py3" tag anymore](https://discourse.girder.org/t/dropping-python-2-support/317/4).
The "latest" tag points to the python3 version, and python2 is no
longer supported by girder.

We can alternatively use a specific version, such as "3.1.0", if we want
to lock down a version.