### PR TITLE
Remove path collision

### DIFF
--- a/girder/molecules/molecules/models/calculation.py
+++ b/girder/molecules/molecules/models/calculation.py
@@ -153,7 +153,7 @@ class Calculation(AccessControlledModel):
                 }
 
         fields = ['image', 'input', 'code',
-                  'cjson', 'cjson.vibrations.modes', 'cjson.vibrations.intensities',
+                  'cjson.vibrations.modes', 'cjson.vibrations.intensities',
                   'cjson.vibrations.frequencies', 'properties', 'fileId', 'access',
                   'moleculeId', 'public']
 


### PR DESCRIPTION
Starting in MongoDB 4.4, it is illegal to project an embedded document with any of the embedded document’s fields.